### PR TITLE
fix: improve PostgreSQL connection reliability and latency

### DIFF
--- a/crates/db/src/manager.rs
+++ b/crates/db/src/manager.rs
@@ -304,10 +304,21 @@ impl ConnectionManager {
         config: DbConnectionConfig,
         db_manager: &DbManager,
     ) -> Result<String, DbError> {
+        let session_started = Instant::now();
         let config_id = config.id.clone();
+        let database_type = config.database_type;
+        let database = config.database.clone();
 
         // Try to acquire an existing session and switch database if needed
         if let Some(session_id) = self.try_acquire_session(&config).await? {
+            info!(
+                "[DB][Timing] create_session reused config_id={} database_type={:?} database={:?} session_id={} elapsed={}ms",
+                config_id,
+                database_type,
+                database,
+                session_id,
+                session_started.elapsed().as_millis()
+            );
             return Ok(session_id);
         }
 
@@ -315,10 +326,16 @@ impl ConnectionManager {
 
         // Create new connection
         let plugin = db_manager.get_plugin(&config.database_type)?;
-        let mut connection = plugin.create_connection(config.clone()).await?;
-
-        // Connect to database
-        connection.connect().await?;
+        let connect_started = Instant::now();
+        let connection = plugin.create_connection(config.clone()).await?;
+        info!(
+            "[DB][Timing] create_session connect config_id={} database_type={:?} database={:?} session_id={} elapsed={}ms",
+            config_id,
+            database_type,
+            database,
+            session_id,
+            connect_started.elapsed().as_millis()
+        );
         info!(
             "Created new session: {} (database: {:?})",
             session_id, config.database
@@ -334,6 +351,13 @@ impl ConnectionManager {
             .or_insert_with(Vec::new)
             .push(session);
 
+        info!(
+            "[DB][Timing] create_session total database_type={:?} database={:?} session_id={} elapsed={}ms",
+            database_type,
+            database,
+            session_id,
+            session_started.elapsed().as_millis()
+        );
         Ok(session_id)
     }
 
@@ -668,8 +692,7 @@ impl ConnectionPool {
         _db_manager: &DbManager,
     ) -> anyhow::Result<Arc<RwLock<Box<dyn DbConnection + Send + Sync>>>> {
         let plugin = self.db_manager.get_plugin(&config.database_type)?;
-        let mut connection = plugin.create_connection(config).await?;
-        connection.connect().await?;
+        let connection = plugin.create_connection(config).await?;
         Ok(Arc::new(RwLock::new(connection)))
     }
 }
@@ -963,7 +986,7 @@ impl GlobalDbState {
         opts: Option<ExecOptions>,
         schema_to_switch: Option<String>,
     ) -> anyhow::Result<Vec<SqlResult>> {
-        // 获取缓存实例用于 DDL 失效
+        // Access the cache used for DDL invalidation.
         let cache = cx.update(|cx| cx.try_global::<GlobalNodeCache>().cloned());
 
         let cache_ctx = cx.update(|cx| {
@@ -1040,7 +1063,7 @@ impl GlobalDbState {
         })
         .await?;
 
-        // 执行成功后，处理 DDL 缓存失效
+        // Process DDL cache invalidation after successful execution.
         if let Some(cache) = cache {
             let ddl_info = Tokio::spawn_result(cx, async move {
                 Ok(cache
@@ -1055,7 +1078,7 @@ impl GlobalDbState {
             })
             .await;
 
-            // 如果检测到 DDL 变更，发射 SchemaChanged 事件
+            // Emit a SchemaChanged event when DDL changes are detected.
             if let Ok(Some((conn_id, database, schema))) = ddl_info {
                 if let Some(notifier) = notifier {
                     cx.update(|cx| {
@@ -1291,16 +1314,17 @@ impl GlobalDbState {
         connection_id: String,
         node: DbNode,
     ) -> anyhow::Result<Vec<DbNode>> {
-        // 获取连接配置
+        let load_started = Instant::now();
+        // Resolve the connection config for the current node.
         let mut config = self
             .get_config(&connection_id)
             .ok_or_else(|| anyhow::anyhow!("Connection not found: {}", connection_id))?
             .clone();
 
-        // 创建缓存上下文
+        // Build the cache context up front for cache lookup and write-back.
         let cache_ctx = crate::CacheContext::from_config(&config);
 
-        // 获取缓存实例
+        // Access the global node cache if it is available.
         let cache = cx.update(|cx| cx.try_global::<crate::GlobalNodeCache>().cloned());
 
         // For Database and Schema nodes, we need to connect to the specific database
@@ -1313,30 +1337,51 @@ impl GlobalDbState {
 
         let clone_self = self.clone();
         let node_clone = node.clone();
+        let connection_id_for_ui = connection_id.clone();
+        let node_for_ui = node.clone();
 
-        Tokio::spawn_result(cx, async move {
-            // 尝试从缓存获取
+        let result = Tokio::spawn_result(cx, async move {
+            let async_started = Instant::now();
+            // Try cache first to avoid unnecessary session creation.
             if let Some(ref cache) = cache {
                 if let Some(cached) = cache.get_node(&cache_ctx, &node_clone.id).await {
                     if Self::cached_children_ready(&cached) {
                         tracing::debug!("Cache hit for node: {}", node_clone.id);
+                        info!(
+                            "[DB][Timing] load_node_children cache_hit connection_id={} node_id={} node_type={:?} children={} elapsed={}ms",
+                            connection_id,
+                            node_clone.id,
+                            node_clone.node_type,
+                            cached.children.len(),
+                            async_started.elapsed().as_millis()
+                        );
                         return Ok(cached.children);
                     }
                 }
             }
 
-            // 缓存未命中，从数据库加载
+            // Cache miss. Load children from the database.
             tracing::debug!(
                 "Cache miss for node: {}, loading from database",
                 node_clone.id
             );
 
             let plugin = clone_self.get_plugin(&config.database_type)?;
+            let session_started = Instant::now();
             let session_id = clone_self
                 .connection_manager
                 .create_session(config.clone(), &clone_self.db_manager)
                 .await?;
+            info!(
+                "[DB][Timing] load_node_children create_session connection_id={} node_id={} node_type={:?} session_id={} elapsed={}ms",
+                connection_id,
+                node_clone.id,
+                node_clone.node_type,
+                session_id,
+                session_started.elapsed().as_millis()
+            );
 
+            let fetch_started = Instant::now();
             let result = {
                 let mut guard = clone_self
                     .connection_manager
@@ -1350,16 +1395,33 @@ impl GlobalDbState {
                     .await
                     .map_err(|e| anyhow::anyhow!("{}", e))
             };
+            info!(
+                "[DB][Timing] load_node_children fetch connection_id={} node_id={} node_type={:?} session_id={} elapsed={}ms",
+                connection_id,
+                node_clone.id,
+                node_clone.node_type,
+                session_id,
+                fetch_started.elapsed().as_millis()
+            );
 
+            let release_started = Instant::now();
             if let Err(e) = clone_self
                 .connection_manager
                 .release_session(&session_id)
                 .await
             {
                 warn!("Failed to release session {}: {}", session_id, e);
+            } else {
+                info!(
+                    "[DB][Timing] load_node_children release_session connection_id={} node_id={} session_id={} elapsed={}ms",
+                    connection_id,
+                    node_clone.id,
+                    session_id,
+                    release_started.elapsed().as_millis()
+                );
             }
 
-            // 如果加载成功，缓存结果
+            // Persist successful results back to the cache.
             if let Ok(ref children) = result {
                 if let Some(ref cache) = cache {
                     let mut node_with_children = node_clone.clone();
@@ -1375,11 +1437,41 @@ impl GlobalDbState {
                         children.len()
                     );
                 }
+                info!(
+                    "[DB][Timing] load_node_children total connection_id={} node_id={} node_type={:?} children={} elapsed={}ms",
+                    connection_id,
+                    node_clone.id,
+                    node_clone.node_type,
+                    children.len(),
+                    async_started.elapsed().as_millis()
+                );
+            } else if let Err(ref error) = result {
+                warn!(
+                    "[DB][Timing] load_node_children failed connection_id={} node_id={} node_type={:?} elapsed={}ms error={}",
+                    connection_id,
+                    node_clone.id,
+                    node_clone.node_type,
+                    async_started.elapsed().as_millis(),
+                    error
+                );
             }
 
             result
         })
-        .await
+        .await;
+
+        if let Ok(children) = &result {
+            info!(
+                "[DB][Timing] load_node_children ui_total connection_id={} node_id={} node_type={:?} children={} elapsed={}ms",
+                connection_id_for_ui,
+                node_for_ui.id,
+                node_for_ui.node_type,
+                children.len(),
+                load_started.elapsed().as_millis()
+            );
+        }
+
+        result
     }
 
     /// Apply table changes
@@ -1435,10 +1527,10 @@ impl GlobalDbState {
         cx: &mut AsyncApp,
         connection_id: String,
     ) -> anyhow::Result<Vec<String>> {
-        // 获取缓存实例
+        // Access the cache instance.
         let cache = cx.update(|cx| cx.try_global::<GlobalNodeCache>().cloned());
 
-        // 尝试从缓存获取
+        // Try the cache first.
         if let Some(cache) = cache.clone() {
             let conn_id = connection_id.clone();
             let result = Tokio::spawn_result(cx, async move {
@@ -1455,13 +1547,13 @@ impl GlobalDbState {
             }
         }
 
-        // 缓存未命中，从数据库查询
+        // Cache miss. Query the database.
         let conn_id = connection_id.clone();
         let databases = with_plugin_session!(self, cx, connection_id, |plugin, conn| {
             plugin.list_databases(&*conn).await
         })?;
 
-        // 写入缓存
+        // Persist the result in cache.
         if let Some(cache) = cache {
             let databases_clone = databases.clone();
             Tokio::spawn(cx, async move {
@@ -1508,10 +1600,10 @@ impl GlobalDbState {
         connection_id: String,
         database: String,
     ) -> anyhow::Result<Vec<String>> {
-        // 获取缓存实例
+        // Access the cache instance.
         let cache = cx.update(|cx| cx.try_global::<GlobalNodeCache>().cloned());
 
-        // 尝试从缓存获取
+        // Try the cache first.
         if let Some(cache) = cache.clone() {
             let conn_id = connection_id.clone();
             let db = database.clone();
@@ -1529,7 +1621,7 @@ impl GlobalDbState {
             }
         }
 
-        // 缓存未命中，从数据库查询
+        // Cache miss. Query the database.
         let conn_id = connection_id.clone();
         let db = database.clone();
         let schemas =
@@ -1537,7 +1629,7 @@ impl GlobalDbState {
                 plugin.list_schemas(&*conn, &database).await
             })?;
 
-        // 写入缓存
+        // Persist the result in cache.
         if let Some(cache) = cache {
             let schemas_clone = schemas.clone();
             Tokio::spawn(cx, async move {
@@ -1558,10 +1650,10 @@ impl GlobalDbState {
         database: String,
         schema: Option<String>,
     ) -> anyhow::Result<Vec<crate::types::TableInfo>> {
-        // 获取缓存实例
+        // Access the cache instance.
         let cache = cx.update(|cx| cx.try_global::<GlobalNodeCache>().cloned());
 
-        // 尝试从缓存获取
+        // Try the cache first.
         if let Some(cache) = cache.clone() {
             let conn_id = connection_id.clone();
             let db = database.clone();
@@ -1580,7 +1672,7 @@ impl GlobalDbState {
             }
         }
 
-        // 缓存未命中，从数据库查询
+        // Cache miss. Query the database.
         let conn_id = connection_id.clone();
         let db = database.clone();
         let sch = schema.clone();
@@ -1589,7 +1681,7 @@ impl GlobalDbState {
                 plugin.list_tables(&*conn, &database, schema).await
             })?;
 
-        // 写入缓存
+        // Persist the result in cache.
         if let Some(cache) = cache {
             let tables_clone = tables.clone();
             Tokio::spawn(cx, async move {
@@ -1626,10 +1718,10 @@ impl GlobalDbState {
         schema: Option<String>,
         table: String,
     ) -> anyhow::Result<Vec<crate::types::ColumnInfo>> {
-        // 获取缓存实例
+        // Access the cache instance.
         let cache = cx.update(|cx| cx.try_global::<GlobalNodeCache>().cloned());
 
-        // 尝试从缓存获取
+        // Try the cache first.
         if let Some(cache) = cache.clone() {
             let conn_id = connection_id.clone();
             let db = database.clone();
@@ -1656,7 +1748,7 @@ impl GlobalDbState {
             }
         }
 
-        // 缓存未命中，从数据库查询
+        // Cache miss. Query the database.
         let conn_id = connection_id.clone();
         let db = database.clone();
         let sch = schema.clone();
@@ -1666,7 +1758,7 @@ impl GlobalDbState {
                 plugin.list_columns(&*conn, &database, schema, &table).await
             })?;
 
-        // 写入缓存
+        // Persist the result in cache.
         if let Some(cache) = cache {
             let columns_clone = columns.clone();
             Tokio::spawn(cx, async move {
@@ -1706,10 +1798,10 @@ impl GlobalDbState {
         schema: Option<String>,
         table: String,
     ) -> anyhow::Result<Vec<crate::types::IndexInfo>> {
-        // 获取缓存实例
+        // Access the cache instance.
         let cache = cx.update(|cx| cx.try_global::<GlobalNodeCache>().cloned());
 
-        // 尝试从缓存获取
+        // Try the cache first.
         if let Some(cache) = cache.clone() {
             let conn_id = connection_id.clone();
             let db = database.clone();
@@ -1736,7 +1828,7 @@ impl GlobalDbState {
             }
         }
 
-        // 缓存未命中，从数据库查询
+        // Cache miss. Query the database.
         let conn_id = connection_id.clone();
         let db = database.clone();
         let sch = schema.clone();
@@ -1746,7 +1838,7 @@ impl GlobalDbState {
                 plugin.list_indexes(&*conn, &database, schema, &table).await
             })?;
 
-        // 写入缓存
+        // Persist the result in cache.
         if let Some(cache) = cache {
             let indexes_clone = indexes.clone();
             Tokio::spawn(cx, async move {
@@ -1840,6 +1932,15 @@ impl GlobalDbState {
         connection_id: String,
         node: DbNode,
     ) -> anyhow::Result<Option<crate::types::ObjectView>> {
+        if node.node_type == DbNodeType::Connection && !node.children_loaded {
+            info!(
+                "[DB][Timing] load_object_view skipped connection_id={} node_id={} reason=connection_children_not_loaded",
+                connection_id,
+                node.id
+            );
+            return Ok(None);
+        }
+
         let mut config = self
             .get_config(&connection_id)
             .ok_or_else(|| anyhow::anyhow!("Connection not found: {}", connection_id))?

--- a/crates/db/src/postgresql/connection.rs
+++ b/crates/db/src/postgresql/connection.rs
@@ -121,6 +121,13 @@ pub struct PostgresDbConnection {
 }
 
 impl PostgresDbConnection {
+    fn is_loopback_host(host: &str) -> bool {
+        matches!(
+            host.trim().to_ascii_lowercase().as_str(),
+            "localhost" | "127.0.0.1" | "::1"
+        )
+    }
+
     pub fn new(config: DbConnectionConfig) -> Self {
         Self {
             config,
@@ -137,6 +144,8 @@ impl PostgresDbConnection {
         {
             Some("disable") => SslMode::Disable,
             Some("require") => SslMode::Require,
+            Some("prefer") => SslMode::Prefer,
+            _ if Self::is_loopback_host(&config.host) => SslMode::Disable,
             _ => SslMode::Prefer,
         }
     }
@@ -171,8 +180,18 @@ impl PostgresDbConnection {
     }
 
     fn build_root_cert_store(config: &DbConnectionConfig) -> Result<RootCertStore, DbError> {
+        let build_started = Instant::now();
         let mut root_store = RootCertStore::empty();
+        let native_load_started = Instant::now();
         let native_certificates = rustls_native_certs::load_native_certs();
+        let native_cert_count = native_certificates.certs.len();
+        let native_error_count = native_certificates.errors.len();
+        info!(
+            "[PostgreSQL][Timing] load_native_certs={}ms certs={} errors={}",
+            native_load_started.elapsed().as_millis(),
+            native_cert_count,
+            native_error_count
+        );
 
         for error in native_certificates.errors {
             warn!(
@@ -194,7 +213,16 @@ impl PostgresDbConnection {
             .map(|value| value.trim())
             .filter(|value| !value.is_empty())
         {
-            for certificate in Self::load_root_certificates(Path::new(path))? {
+            let custom_load_started = Instant::now();
+            let certificates = Self::load_root_certificates(Path::new(path))?;
+            info!(
+                "[PostgreSQL][Timing] load_custom_root_certs={}ms path={} certs={}",
+                custom_load_started.elapsed().as_millis(),
+                path,
+                certificates.len()
+            );
+
+            for certificate in certificates {
                 root_store.add(certificate).map_err(|error| {
                     DbError::connection_with_source(
                         "failed to add PostgreSQL root certificate",
@@ -204,10 +232,15 @@ impl PostgresDbConnection {
             }
         }
 
+        info!(
+            "[PostgreSQL][Timing] build_root_cert_store={}ms",
+            build_started.elapsed().as_millis()
+        );
         Ok(root_store)
     }
 
     fn build_tls_connector(config: &DbConnectionConfig) -> Result<MakeRustlsConnect, DbError> {
+        let build_started = Instant::now();
         ensure_rustls_crypto_provider();
 
         let accept_invalid_certs = config.get_param_bool("ssl_accept_invalid_certs");
@@ -238,6 +271,12 @@ impl PostgresDbConnection {
             .with_custom_certificate_verifier(verifier)
             .with_no_client_auth();
 
+        info!(
+            "[PostgreSQL][Timing] build_tls_connector={}ms invalid_certs={} invalid_hostnames={}",
+            build_started.elapsed().as_millis(),
+            accept_invalid_certs,
+            accept_invalid_hostnames
+        );
         Ok(MakeRustlsConnect::new(client_config))
     }
 
@@ -415,6 +454,45 @@ impl PostgresDbConnection {
             message: Some(message),
         })
     }
+
+    fn should_retry_without_tls(error: &dyn std::error::Error) -> bool {
+        let mut current = Some(error);
+        while let Some(err) = current {
+            let message = err.to_string().to_ascii_lowercase();
+            if message.contains("invalid peer certificate")
+                || message.contains("unsupportedcertversion")
+                || message.contains("unsupported cert version")
+                || message.contains("certificate verify failed")
+            {
+                return true;
+            }
+            current = err.source();
+        }
+        false
+    }
+
+    async fn connect_without_tls(pg_config: &Config) -> Result<Client, tokio_postgres::Error> {
+        let (client, connection) = pg_config.connect(NoTls).await?;
+        tokio::spawn(async move {
+            if let Err(error) = connection.await {
+                error!("[PostgreSQL] Connection error: {}", error);
+            }
+        });
+        Ok(client)
+    }
+
+    async fn connect_with_tls(
+        pg_config: &Config,
+        tls_connector: MakeRustlsConnect,
+    ) -> Result<Client, tokio_postgres::Error> {
+        let (client, connection) = pg_config.connect(tls_connector).await?;
+        tokio::spawn(async move {
+            if let Err(error) = connection.await {
+                error!("[PostgreSQL] Connection error: {}", error);
+            }
+        });
+        Ok(client)
+    }
 }
 
 #[async_trait]
@@ -432,10 +510,22 @@ impl DbConnection for PostgresDbConnection {
     }
 
     async fn connect(&mut self) -> Result<(), DbError> {
+        let connect_started = Instant::now();
         let config = &self.config;
         info!("[PostgreSQL] Connecting to {}:{}", config.host, config.port);
+        let resolve_started = Instant::now();
         let target = resolve_connection_target(config).await?;
+        let resolve_elapsed_ms = resolve_started.elapsed().as_millis();
         self.tunnel = target.tunnel;
+        info!(
+            "[PostgreSQL][Timing] resolve_connection_target={}ms host={}:{} target={}:{} ssh_tunnel={}",
+            resolve_elapsed_ms,
+            config.host,
+            config.port,
+            target.host,
+            target.port,
+            self.tunnel.is_some()
+        );
 
         let mut pg_config = Config::new();
         pg_config
@@ -466,28 +556,87 @@ impl DbConnection for PostgresDbConnection {
         debug!("[PostgreSQL] Establishing connection...");
         let client = match ssl_mode {
             SslMode::Disable => {
-                let (client, connection) = pg_config.connect(NoTls).await.map_err(|e| {
-                    error!("[PostgreSQL] Connection failed: {}", e);
-                    DbError::connection_with_source("failed to connect", e)
-                })?;
-                tokio::spawn(async move {
-                    if let Err(e) = connection.await {
-                        error!("[PostgreSQL] Connection error: {}", e);
-                    }
-                });
+                let connect_without_tls_started = Instant::now();
+                let client = Self::connect_without_tls(&pg_config)
+                    .await
+                    .map_err(|error| {
+                        error!("[PostgreSQL] Connection failed: {}", error);
+                        DbError::connection_with_source("failed to connect", error)
+                    })?;
+                info!(
+                    "[PostgreSQL][Timing] connect_without_tls={}ms",
+                    connect_without_tls_started.elapsed().as_millis()
+                );
                 client
             }
-            _ => {
+            SslMode::Prefer => {
+                let tls_connector_started = Instant::now();
                 let tls_connector = Self::build_tls_connector(config)?;
-                let (client, connection) = pg_config.connect(tls_connector).await.map_err(|e| {
-                    error!("[PostgreSQL] Connection failed: {}", e);
-                    DbError::connection_with_source("failed to connect", e)
-                })?;
-                tokio::spawn(async move {
-                    if let Err(e) = connection.await {
-                        error!("[PostgreSQL] Connection error: {}", e);
+                info!(
+                    "[PostgreSQL][Timing] prepare_tls_connector={}ms",
+                    tls_connector_started.elapsed().as_millis()
+                );
+                let tls_connect_started = Instant::now();
+                match Self::connect_with_tls(&pg_config, tls_connector).await {
+                    Ok(client) => {
+                        info!(
+                            "[PostgreSQL][Timing] connect_with_tls={}ms ssl_mode=Prefer",
+                            tls_connect_started.elapsed().as_millis()
+                        );
+                        client
                     }
-                });
+                    Err(error) if Self::should_retry_without_tls(&error) => {
+                        warn!(
+                            "[PostgreSQL] TLS connect failed in prefer mode, retrying without TLS: {}",
+                            error
+                        );
+                        info!(
+                            "[PostgreSQL][Timing] connect_with_tls_failed={}ms ssl_mode=Prefer reason={}",
+                            tls_connect_started.elapsed().as_millis(),
+                            error
+                        );
+                        let retry_started = Instant::now();
+                        let client = Self::connect_without_tls(&pg_config)
+                            .await
+                            .map_err(|retry_error| {
+                                error!(
+                                    "[PostgreSQL] Non-TLS retry after TLS failure also failed: {}",
+                                    retry_error
+                                );
+                                DbError::connection_with_source("failed to connect", retry_error)
+                            })?;
+                        info!(
+                            "[PostgreSQL][Timing] retry_without_tls={}ms ssl_mode=Prefer",
+                            retry_started.elapsed().as_millis()
+                        );
+                        client
+                    }
+                    Err(error) => {
+                        error!("[PostgreSQL] Connection failed: {}", error);
+                        return Err(DbError::connection_with_source("failed to connect", error));
+                    }
+                }
+            }
+            _ => {
+                let tls_connector_started = Instant::now();
+                let tls_connector = Self::build_tls_connector(config)?;
+                info!(
+                    "[PostgreSQL][Timing] prepare_tls_connector={}ms ssl_mode={:?}",
+                    tls_connector_started.elapsed().as_millis(),
+                    ssl_mode
+                );
+                let tls_connect_started = Instant::now();
+                let client = Self::connect_with_tls(&pg_config, tls_connector)
+                    .await
+                    .map_err(|error| {
+                        error!("[PostgreSQL] Connection failed: {}", error);
+                        DbError::connection_with_source("failed to connect", error)
+                    })?;
+                info!(
+                    "[PostgreSQL][Timing] connect_with_tls={}ms ssl_mode={:?}",
+                    tls_connect_started.elapsed().as_millis(),
+                    ssl_mode
+                );
                 client
             }
         };
@@ -497,7 +646,11 @@ impl DbConnection for PostgresDbConnection {
             *guard = Some(client);
         }
 
-        info!("[PostgreSQL] Connected successfully");
+        info!(
+            "[PostgreSQL] Connected successfully in {}ms (ssl_mode={:?})",
+            connect_started.elapsed().as_millis(),
+            ssl_mode
+        );
         Ok(())
     }
 
@@ -1441,8 +1594,16 @@ mod tests {
     }
 
     #[test]
-    fn ssl_mode_defaults_to_prefer() {
+    fn ssl_mode_defaults_to_disable_for_loopback_hosts() {
         let config = build_config(&[]);
+
+        assert_eq!(PostgresDbConnection::ssl_mode(&config), SslMode::Disable);
+    }
+
+    #[test]
+    fn ssl_mode_defaults_to_prefer_for_non_loopback_hosts() {
+        let mut config = build_config(&[]);
+        config.host = "db.example.com".to_string();
 
         assert_eq!(PostgresDbConnection::ssl_mode(&config), SslMode::Prefer);
     }
@@ -1474,18 +1635,34 @@ mod tests {
 
     #[test]
     fn ssl_load_root_certificates_rejects_empty_pem_file() {
-        let mut temp_file = NamedTempFile::new().expect("应创建临时文件");
-        writeln!(temp_file, "not a certificate").expect("应写入测试内容");
+        let mut temp_file = NamedTempFile::new().expect("temporary file should be created");
+        writeln!(temp_file, "not a certificate").expect("test contents should be written");
 
         let error = PostgresDbConnection::load_root_certificates(temp_file.path())
-            .expect_err("空 PEM 文件应返回错误");
+            .expect_err("empty PEM file should return an error");
 
         assert!(
             error
                 .to_string()
                 .contains("does not contain any certificates"),
-            "错误信息应指出证书文件为空: {}",
+            "error message should indicate that the certificate file is empty: {}",
             error
         );
+    }
+
+    #[test]
+    fn retry_without_tls_matches_peer_certificate_errors() {
+        let error = std::io::Error::other(
+            "invalid peer certificate: Other(OtherError(UnsupportedCertVersion))",
+        );
+
+        assert!(PostgresDbConnection::should_retry_without_tls(&error));
+    }
+
+    #[test]
+    fn retry_without_tls_ignores_non_tls_errors() {
+        let error = std::io::Error::other("password authentication failed for user postgres");
+
+        assert!(!PostgresDbConnection::should_retry_without_tls(&error));
     }
 }

--- a/crates/db/src/ssh_tunnel.rs
+++ b/crates/db/src/ssh_tunnel.rs
@@ -18,7 +18,7 @@ const SSH_TARGET_HOST: &str = "ssh_target_host";
 const SSH_TARGET_PORT: &str = "ssh_target_port";
 const SSH_TIMEOUT: &str = "ssh_timeout";
 
-/// 默认 SSH 连接超时（秒）
+/// Default SSH connection timeout in seconds.
 const DEFAULT_SSH_TIMEOUT_SECS: u64 = 30;
 
 pub struct ResolvedConnectionTarget {
@@ -27,12 +27,20 @@ pub struct ResolvedConnectionTarget {
     pub tunnel: Option<LocalPortForwardTunnel>,
 }
 
+fn normalize_direct_host(host: &str) -> String {
+    if host.eq_ignore_ascii_case("localhost") {
+        return "127.0.0.1".to_string();
+    }
+
+    host.to_string()
+}
+
 pub async fn resolve_connection_target(
     config: &DbConnectionConfig,
 ) -> Result<ResolvedConnectionTarget, DbError> {
     if !config.get_param_bool(SSH_TUNNEL_ENABLED) {
         return Ok(ResolvedConnectionTarget {
-            host: config.host.clone(),
+            host: normalize_direct_host(&config.host),
             port: config.port,
             tunnel: None,
         });
@@ -49,7 +57,7 @@ pub async fn resolve_connection_target(
         .unwrap_or_else(|| config.host.clone());
     let target_port = optional_u16_param(config, SSH_TARGET_PORT).unwrap_or(config.port);
 
-    // 获取 SSH 连接超时
+    // Read the SSH connection timeout from config.
     let ssh_timeout_secs = config
         .get_param_as::<u64>(SSH_TIMEOUT)
         .unwrap_or(DEFAULT_SSH_TIMEOUT_SECS);
@@ -66,7 +74,7 @@ pub async fn resolve_connection_target(
         proxy: None,
     };
 
-    // 使用 tokio::timeout 包装 SSH 隧道建立
+    // Wrap tunnel setup with an explicit timeout.
     let tunnel_result = timeout(
         Duration::from_secs(ssh_timeout_secs),
         start_local_port_forward(ssh_config, target_host, target_port),
@@ -172,7 +180,7 @@ mod tests {
         extra_params.insert(SSH_AUTH_TYPE.to_string(), "agent".to_string());
         let config = build_config(extra_params);
 
-        let auth = build_auth(&config).expect("agent 认证类型应解析成功");
+        let auth = build_auth(&config).expect("agent auth type should parse successfully");
 
         assert!(matches!(auth, SshAuth::Agent));
     }

--- a/crates/db_view/src/common/db_connection_form.rs
+++ b/crates/db_view/src/common/db_connection_form.rs
@@ -1,4 +1,6 @@
 use anyhow::Error;
+use std::time::Instant;
+
 use db::{GlobalDbState, oracle};
 use gpui::prelude::FluentBuilder;
 use gpui::{
@@ -28,6 +30,7 @@ use one_core::storage::{
     Workspace, get_config_dir,
 };
 use rust_i18n::t;
+use tracing::info;
 
 /// Form select item for dropdown fields
 #[derive(Clone, Debug)]
@@ -1030,9 +1033,9 @@ pub struct DbConnectionForm {
     team_select: Entity<SelectState<Vec<TeamSelectItem>>>,
     pending_file_path: Entity<Option<String>>,
     editing_connection: Option<StoredConnection>,
-    /// 是否启用云同步
+    /// Whether cloud sync is enabled.
     sync_enabled: Entity<bool>,
-    /// Oracle 客户端检测状态：Ok(版本) / Err(错误)
+    /// Oracle client detection status: Ok(version) / Err(error).
     oracle_client_status: Entity<Option<Result<String, String>>>,
     oracle_client_checking: Entity<bool>,
 }
@@ -1145,7 +1148,7 @@ impl DbConnectionForm {
 
         let pending_file_path = cx.new(|_| None);
 
-        // 默认启用云同步
+        // Enable cloud sync by default.
         let sync_enabled = cx.new(|_| true);
         let oracle_client_status = cx.new(|_| None);
         let oracle_client_checking = cx.new(|_| false);
@@ -1282,7 +1285,7 @@ impl DbConnectionForm {
         self.editing_connection = Some(connection.clone());
         self.set_field_value("name", &connection.name, window, cx);
 
-        // 加载同步状态
+        // Load the sync state.
         self.sync_enabled.update(cx, |sync, cx| {
             *sync = connection.sync_enabled;
             cx.notify();
@@ -1321,7 +1324,7 @@ impl DbConnectionForm {
             });
         }
 
-        // 加载团队归属
+        // Load team ownership.
         if let Some(ref team_id) = connection.team_id {
             self.team_select.update(cx, |select, cx| {
                 select.set_selected_value(&Some(team_id.clone()), window, cx);
@@ -1490,7 +1493,7 @@ impl DbConnectionForm {
             .map(|e| e.to_string())
             .unwrap_or_else(|| err.to_string());
 
-        // 去掉常见包装前缀，只保留最有价值的底层异常信息。
+        // Strip common wrapper prefixes and keep the most useful root-level message.
         let prefixes = [
             "connection error: ",
             "query error: ",
@@ -1546,9 +1549,47 @@ impl DbConnectionForm {
             let manager = global_state.db_manager;
 
             let test_result = Tokio::spawn_result(cx, async move {
+                let test_started = Instant::now();
                 let db_plugin = manager.get_plugin(&db_type)?;
-                let conn = db_plugin.create_connection(connection).await?;
-                conn.ping().await?;
+                let connect_started = Instant::now();
+                let conn = match db_plugin.create_connection(connection).await {
+                    Ok(conn) => conn,
+                    Err(error) => {
+                        info!(
+                            "[DB][Timing] test_connection failed stage=create_connection db_type={:?} elapsed={}ms error={}",
+                            db_type,
+                            test_started.elapsed().as_millis(),
+                            error
+                        );
+                        return Err(Error::new(error));
+                    }
+                };
+                info!(
+                    "[DB][Timing] test_connection create_connection db_type={:?} elapsed={}ms",
+                    db_type,
+                    connect_started.elapsed().as_millis()
+                );
+
+                let ping_started = Instant::now();
+                if let Err(error) = conn.ping().await {
+                    info!(
+                        "[DB][Timing] test_connection failed stage=ping db_type={:?} elapsed={}ms error={}",
+                        db_type,
+                        test_started.elapsed().as_millis(),
+                        error
+                    );
+                    return Err(Error::new(error));
+                }
+                info!(
+                    "[DB][Timing] test_connection ping db_type={:?} elapsed={}ms",
+                    db_type,
+                    ping_started.elapsed().as_millis()
+                );
+                info!(
+                    "[DB][Timing] test_connection total db_type={:?} elapsed={}ms",
+                    db_type,
+                    test_started.elapsed().as_millis()
+                );
                 Ok::<bool, Error>(true)
             })
             .await;
@@ -1598,7 +1639,7 @@ impl DbConnectionForm {
                 c.team_id = team_id;
                 c.params = serde_json::to_string(&connection)
                     .map_err(|e| format!("{}: {}", t!("ConnectionForm.serialize_failed"), e))?;
-                // 更新 selected_databases 以匹配新的 database 配置
+                // Keep selected_databases aligned with the current database config.
                 c.selected_databases = if let Some(database) = &connection.database {
                     Some(format!("[\"{}\"]", database))
                 } else {
@@ -1610,7 +1651,7 @@ impl DbConnectionForm {
                 let mut c = StoredConnection::from_db_connection(connection);
                 c.sync_enabled = sync_enabled;
                 c.team_id = team_id;
-                // 新建时自动填充 owner_id
+                // Auto-fill owner_id for newly created connections.
                 c.owner_id = GlobalCloudUser::get_user(cx).map(|u| u.id);
                 c
             }
@@ -1635,7 +1676,7 @@ impl DbConnectionForm {
         *self.is_testing.read(cx)
     }
 
-    /// 返回测试连接结果的显示文字，无结果时返回 None
+    /// Returns the display string for the test-connection result, or None if absent.
     pub fn test_result_msg(&self, cx: &App) -> Option<String> {
         self.test_result.read(cx).as_ref().map(|r| match r {
             Ok(true) => format!("✓ {}", t!("ConnectionForm.test_success")),
@@ -2420,7 +2461,7 @@ mod tests {
             .tab_groups
             .iter()
             .find(|group| group.name == "ssl")
-            .expect("MySQL 应包含 SSL 标签页");
+            .expect("MySQL should include the SSL tab");
 
         assert_eq!(
             field_names(ssl_tab),
@@ -2448,7 +2489,7 @@ mod tests {
             .tab_groups
             .iter()
             .find(|group| group.name == "ssh")
-            .expect("MySQL 应包含 SSH 标签页");
+            .expect("MySQL should include the SSH tab");
 
         assert_eq!(
             field_names(ssh_tab),


### PR DESCRIPTION
## 变更说明

本次改动聚焦修复 PostgreSQL 连接阶段的可靠性和延迟问题，目标是减少本地/SSH 场景下不必要的连接开销，并提升连接失败时的兼容性和可观测性。

具体改动如下：
- PostgreSQL 默认在回环地址（`localhost` / `127.0.0.1` / `::1`）下关闭 SSL，避免本地连接仍走 TLS 协商和证书加载导致额外延迟。
- PostgreSQL 在 `ssl_mode=prefer` 时，若 TLS 建连因证书版本等兼容性问题失败，会自动回退到非 TLS 连接，降低连接失败概率。
- 直连场景会将 `localhost` 规范化为 `127.0.0.1`，避免部分环境下主机解析和协议选择带来的额外开销。
- 为 PostgreSQL 建连、证书加载、会话创建、节点加载和“测试连接”流程补充分阶段耗时日志，便于定位慢点。
- 调整数据库会话复用与对象加载细节，避免无意义的重复连接，并在连接节点尚未完成子节点加载时跳过对象视图查询。

## 截图

| 修改前 | 修改后 |
| 
<img width="666" height="56" alt="1" src="https://github.com/user-attachments/assets/eb55a16b-3677-45db-9bab-1300f5a5f2ff" />
 | 
<img width="688" height="652" alt="2" src="https://github.com/user-attachments/assets/f148a19c-be5b-4951-b1d3-3be89fc4a606" />
 |
| PostgreSQL 本地或 `prefer` 场景可能先走 TLS，出现连接慢、证书失败即报错，且难以定位耗时阶段 | 本地回环地址默认直连，`prefer` 模式支持失败后回退到非 TLS，并可通过日志明确看到各阶段耗时 |

## 破坏性变更

无。

## 验证方式

1. 已在 Windows 环境执行 `cargo test -p db ssl_mode_defaults_to_disable_for_loopback_hosts -- --nocapture`，验证回环地址默认禁用 SSL 的逻辑。
2. 已在 Windows 环境执行 `cargo test -p db retry_without_tls_matches_peer_certificate_errors -- --nocapture`，验证 `ssl_mode=prefer` 下的 TLS 失败回退判断逻辑。
3. 建议后续补充手工验证：配置一个使用 `localhost` 或 `127.0.0.1` 的 PostgreSQL 连接，执行“测试连接”并确认能够跳过不必要的 TLS 协商。
4. 建议后续补充手工验证：配置 `ssl_mode=prefer` 的 PostgreSQL 连接，在服务端 TLS 证书不兼容或不支持时确认能够自动回退到非 TLS 连接。
5. 建议后续补充手工验证：在直连和 SSH 隧道场景下展开数据库树节点，确认连接建立、节点加载和会话复用流程正常，并检查日志输出中的阶段耗时信息。

## 检查清单

- [x] 我已阅读 [CONTRIBUTING](../CONTRIBUTING.md) 并遵循相关规范。
- [x] 我已检查本次 PR 的改动，并确认 AI 生成代码（如有）内容准确。
- [x] 我已在 Windows 环境执行与 PostgreSQL 连接修复相关的定向单测验证。
- [ ] 我尚未完成 macOS 和 Linux 环境下的实际运行验证。
