### PR TITLE
fix(edit_table): 修复双击编辑时单元格内容位移

### DIFF
--- a/crates/one_ui/src/edit_table/delegate.rs
+++ b/crates/one_ui/src/edit_table/delegate.rs
@@ -43,6 +43,7 @@ impl CellEditor {
                 .h_full()
                 .text_base()
                 .appearance(false)
+                .bare()
                 .into_any_element(),
             CellEditor::DatePicker(picker) => DatePicker::new(picker)
                 .w_full()

--- a/crates/one_ui/src/edit_table/state.rs
+++ b/crates/one_ui/src/edit_table/state.rs
@@ -1980,35 +1980,43 @@ where
                 this.bg(cx.theme().warning.opacity(0.15))
             });
 
+        // 统一布局：编辑和显示模式使用相同的容器 padding
+        cell = cell.table_cell_size(self.options.size);
+
+        let size_pad = self.options.size.table_cell_padding();
+        let (target_pt, target_pb, target_pl, target_pr) = match col_padding {
+            Some(p) => (p.top, p.bottom, p.left, p.right),
+            None => (
+                size_pad.top,
+                size_pad.bottom,
+                size_pad.left,
+                size_pad.right,
+            ),
+        };
+
+        // 边框补偿：编辑态始终有 border_2；显示态仅选中时有
+        let (has_t, has_b, has_l, has_r) = if is_editing {
+            (true, true, true, true)
+        } else {
+            (
+                border_top || is_single_select_active,
+                border_bottom || is_single_select_active,
+                border_left || is_single_select_active,
+                border_right || is_single_select_active,
+            )
+        };
+        let b = px(2.);
+        cell = cell
+            .pt(if has_t { (target_pt - b).max(px(0.)) } else { target_pt })
+            .pb(if has_b { (target_pb - b).max(px(0.)) } else { target_pb })
+            .pl(if has_l { (target_pl - b).max(px(0.)) } else { target_pl })
+            .pr(if has_r { (target_pr - b).max(px(0.)) } else { target_pr });
+
+        // 编辑模式：嵌入轻量编辑器（无自带样式，由容器控制布局）
         if is_editing {
             if let Some(editor) = &self.editing_input {
                 cell = cell.child(editor.render(window, cx));
             }
-        } else {
-            cell = cell.table_cell_size(self.options.size);
-
-            let size_pad = self.options.size.table_cell_padding();
-            let (target_pt, target_pb, target_pl, target_pr) = match col_padding {
-                Some(p) => (p.top, p.bottom, p.left, p.right),
-                None => (
-                    size_pad.top,
-                    size_pad.bottom,
-                    size_pad.left,
-                    size_pad.right,
-                ),
-            };
-
-            // 选中时 border 占用内部空间会挤压内容区，减少等量 padding 补偿
-            let has_t = border_top || is_single_select_active;
-            let has_b = border_bottom || is_single_select_active;
-            let has_l = border_left || is_single_select_active;
-            let has_r = border_right || is_single_select_active;
-            let b = px(2.);
-            cell = cell
-                .pt(if has_t { (target_pt - b).max(px(0.)) } else { target_pt })
-                .pb(if has_b { (target_pb - b).max(px(0.)) } else { target_pb })
-                .pl(if has_l { (target_pl - b).max(px(0.)) } else { target_pl })
-                .pr(if has_r { (target_pr - b).max(px(0.)) } else { target_pr });
         }
 
         cell

--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -49,6 +49,7 @@ pub struct Input {
     focus_bordered: bool,
     tab_index: isize,
     selected: bool,
+    bare: bool,
 }
 
 impl Sizable for Input {
@@ -87,6 +88,7 @@ impl Input {
             focus_bordered: true,
             tab_index: 0,
             selected: false,
+            bare: false,
         }
     }
 
@@ -145,6 +147,13 @@ impl Input {
     /// Set to disable the input field.
     pub fn disabled(mut self, disabled: bool) -> Self {
         self.disabled = disabled;
+        self
+    }
+
+    /// 纯编辑器模式：去掉 Input 自带的 padding、height、items_center 等布局样式，
+    /// 完全由父容器控制布局。用于嵌入表格单元格等场景。
+    pub fn bare(mut self) -> Self {
+        self.bare = true;
         self
     }
 
@@ -373,14 +382,14 @@ impl RenderOnce for Input {
             .on_mouse_move(window.listener_for(&self.state, InputState::on_mouse_move))
             .on_scroll_wheel(window.listener_for(&self.state, InputState::on_scroll_wheel))
             .size_full()
-            .line_height(LINE_HEIGHT)
-            .input_px(self.size)
-            .input_py(self.size)
-            .input_h(self.size)
+            .when(!self.bare, |this| this.line_height(LINE_HEIGHT))
             .input_text_size(self.size)
+            .when(!self.bare, |this| this.input_px(self.size))
+            .when(!self.bare, |this| this.input_py(self.size))
+            .when(!self.bare, |this| this.input_h(self.size))
             .when(!self.disabled, |this| this.cursor_text())
-            .items_center()
-            .when(state.mode.is_multi_line(), |this| {
+            .when(!self.bare, |this| this.items_center())
+            .when(state.mode.is_multi_line() && !self.bare, |this| {
                 this.h_auto()
                     .when_some(self.height, |this, height| this.h(height))
             })
@@ -398,7 +407,7 @@ impl RenderOnce for Input {
                             })
                     })
             })
-            .items_center()
+            .when(!self.bare, |this| this.items_center())
             .gap(gap_x)
             .refine_style(&self.style)
             .children(prefix)


### PR DESCRIPTION
编辑模式和显示模式走了两套不同的布局路径，前者完全跳过
table_cell_size 和边框补偿，渲染的 Input 组件又自带 py/px，
导致文本位置不一致。

改动：
- 统一 render_cell 的容器布局，两种模式共用 table_cell_size + 边框补偿
- Input 新增 bare() 模式，跳过自带的 padding/height/items_center， 
  让父容器完全控制布局，保留所有键盘/鼠标事件处理


| Before                       | After                       |
| ---------------------------- | --------------------------- |
| <img alt="before" src="https://github.com/user-attachments/assets/62469691-82fa-4d37-a30d-667364d5b2ab" /> | <img alt="after" src="https://github.com/user-attachments/assets/773fffa4-aafe-4011-bb8d-933ec6ae7b1d" /> |
